### PR TITLE
Add biome system and weighted random selection logic

### DIFF
--- a/assets/biomes.json
+++ b/assets/biomes.json
@@ -1,0 +1,58 @@
+{
+  "biomes": [
+    {
+      "id": "mild_meadow",
+      "name": "Mild Meadow",
+      "visual": {
+        "color": "4DCC4DFF",
+        "texture": null
+      },
+      "spawnRules": {
+        "clusterCenterChance": 0.01,
+        "resources": [
+          {
+            "resourceId": "chamomile",
+            "weight": 0.7
+          },
+          {
+            "resourceId": "mint",
+            "weight": 0.3
+          }
+        ]
+      }
+    },
+    {
+      "id": "groovy_grove",
+      "name": "Groovy Grove",
+      "visual": {
+        "color": "1A661AFF",
+        "texture": null
+      },
+      "spawnRules": {
+        "clusterCenterChance": 0.005,
+        "resources": [
+          {
+            "resourceId": "mint",
+            "weight": 0.6
+          },
+          {
+            "resourceId": "echinacea",
+            "weight": 0.4
+          }
+        ]
+      }
+    },
+    {
+      "id": "spooky_swamp",
+      "name": "Spooky Swamp",
+      "visual": {
+        "color": "0D401AFF",
+        "texture": null
+      },
+      "spawnRules": {
+        "clusterCenterChance": 0.0,
+        "resources": []
+      }
+    }
+  ]
+}

--- a/assets/biomes.json
+++ b/assets/biomes.json
@@ -3,6 +3,7 @@
     {
       "id": "mild_meadow",
       "name": "Mild Meadow",
+      "worldGenWeight": 1.0,
       "visual": {
         "color": "4DCC4DFF",
         "texture": null
@@ -24,6 +25,7 @@
     {
       "id": "groovy_grove",
       "name": "Groovy Grove",
+      "worldGenWeight": 0.8,
       "visual": {
         "color": "1A661AFF",
         "texture": null
@@ -45,6 +47,7 @@
     {
       "id": "spooky_swamp",
       "name": "Spooky Swamp",
+      "worldGenWeight": 0.2,
       "visual": {
         "color": "0D401AFF",
         "texture": null

--- a/core/src/main/java/com/nova/healersinc/HealersIncGame.java
+++ b/core/src/main/java/com/nova/healersinc/HealersIncGame.java
@@ -7,6 +7,7 @@ import com.badlogic.gdx.graphics.GL20;
 import com.nova.healersinc.interaction.TileInteractionHandler;
 import com.nova.healersinc.render.MapRenderer;
 import com.nova.healersinc.ui.GameUI;
+import com.nova.healersinc.world.BiomeRegistry;
 import com.nova.healersinc.world.ResourceRegistry;
 import com.nova.healersinc.world.WorldGenerator;
 import com.nova.healersinc.world.WorldMap;
@@ -24,6 +25,7 @@ public class HealersIncGame extends ApplicationAdapter {
     public void create() {
 
         ResourceRegistry.init();
+        BiomeRegistry.init();
         WorldGenerator generator = new WorldGenerator(69161L);
         worldMap = generator.generate(500, 500);
 

--- a/core/src/main/java/com/nova/healersinc/render/MapRenderer.java
+++ b/core/src/main/java/com/nova/healersinc/render/MapRenderer.java
@@ -94,10 +94,10 @@ public class MapRenderer {
      */
     private void getBiomeColor(BiomeType biome, Color outColor) {
         switch (biome) {
-            case SUNNY_MEADOW:
+            case MILD_MEADOW:
                 outColor.set(0.3f, 0.8f, 0.3f, 1f);
                 break;
-            case SHADY_GROVE:
+            case GROOVY_GROVE:
                 outColor.set(0.1f, 0.4f, 0.1f, 1f);
                 break;
             default:

--- a/core/src/main/java/com/nova/healersinc/render/MapRenderer.java
+++ b/core/src/main/java/com/nova/healersinc/render/MapRenderer.java
@@ -93,16 +93,11 @@ public class MapRenderer {
      * Gets the color for a specific biome type
      */
     private void getBiomeColor(BiomeType biome, Color outColor) {
-        switch (biome) {
-            case MILD_MEADOW:
-                outColor.set(0.3f, 0.8f, 0.3f, 1f);
-                break;
-            case GROOVY_GROVE:
-                outColor.set(0.1f, 0.4f, 0.1f, 1f);
-                break;
-            default:
-                outColor.set(0.5f, 0.5f, 0.5f, 1f); // fallback gray
-                break;
+        if (biome != null) {
+            BiomeDefinition def = BiomeRegistry.getDefinition(biome);
+            outColor.set(def.getVisual().getColor());
+        } else {
+            outColor.set(Color.GRAY);
         }
     }
 

--- a/core/src/main/java/com/nova/healersinc/world/BiomeConfig.java
+++ b/core/src/main/java/com/nova/healersinc/world/BiomeConfig.java
@@ -8,6 +8,7 @@ public class BiomeConfig {
     public static class BiomeEntry {
         public String id;
         public String name;
+        public float worldGenWeight;
         public Visual visual;
         public SpawnRules spawnRules;
     }

--- a/core/src/main/java/com/nova/healersinc/world/BiomeConfig.java
+++ b/core/src/main/java/com/nova/healersinc/world/BiomeConfig.java
@@ -1,0 +1,29 @@
+package com.nova.healersinc.world;
+
+import java.util.List;
+
+public class BiomeConfig {
+    public List<BiomeEntry> biomes;
+
+    public static class BiomeEntry {
+        public String id;
+        public String name;
+        public Visual visual;
+        public SpawnRules spawnRules;
+    }
+
+    public static class Visual {
+        public String color;
+        public String texture;
+    }
+
+    public static class SpawnRules {
+        public float clusterCenterChance;
+        public List<ResourceSpawn> resources;
+    }
+
+    public static class ResourceSpawn {
+        public String resourceId;
+        public float weight;
+    }
+}

--- a/core/src/main/java/com/nova/healersinc/world/BiomeDefinition.java
+++ b/core/src/main/java/com/nova/healersinc/world/BiomeDefinition.java
@@ -1,0 +1,120 @@
+package com.nova.healersinc.world;
+
+import com.badlogic.gdx.graphics.Color;
+
+import java.util.List;
+import java.util.Random;
+
+public class BiomeDefinition {
+    private final String id;
+    private final String name;
+    private final Visual visual;
+    private final SpawnRules spawnRules;
+
+    public BiomeDefinition(String id, String name, Visual visual, SpawnRules spawnRules) {
+        this.id = id;
+        this.name = name;
+        this.visual = visual;
+        this.spawnRules = spawnRules;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Visual getVisual() {
+        return visual;
+    }
+
+    public SpawnRules getSpawnRules() {
+        return spawnRules;
+    }
+
+    public static class Visual {
+        private final Color color;
+        private final String texture;
+
+        public Visual(Color color, String texture) {
+            this.color = color;
+            this.texture = texture;
+        }
+
+        public Color getColor() {
+            return color;
+        }
+
+        public String getTexture() {
+            return texture;
+        }
+    }
+
+    public static class SpawnRules {
+        private final float clusterCenterChance;
+        private final List<ResourceSpawn> resources;
+        private final float totalWeight;
+
+        public SpawnRules(float clusterCenterChance, List<ResourceSpawn> resources) {
+            this.clusterCenterChance = clusterCenterChance;
+            this.resources = resources;
+
+            // Pre-calculate total weight for efficient random selection
+            float sum = 0f;
+            for (ResourceSpawn spawn : resources) {
+                sum += spawn.getWeight();
+            }
+            this.totalWeight = sum;
+        }
+
+        public float getClusterCenterChance() {
+            return clusterCenterChance;
+        }
+
+        public List<ResourceSpawn> getResources() {
+            return resources;
+        }
+
+        /**
+         * Picks a random herb based on weighted probabilities
+         */
+        public HerbType pickRandomHerb(Random random) {
+            if (resources.isEmpty()) {
+                return HerbType.CHAMOMILE; // fallback
+            }
+
+            float roll = random.nextFloat() * totalWeight;
+            float cumulative = 0f;
+
+            for (ResourceSpawn spawn : resources) {
+                cumulative += spawn.getWeight();
+                if (roll <= cumulative) {
+                    return spawn.getResource();
+                }
+            }
+
+            // Fallback (shouldn't happen)
+            return resources.get(0).getResource();
+        }
+    }
+
+    public static class ResourceSpawn {
+        private final HerbType resource;
+        private final float weight;
+
+        public ResourceSpawn(HerbType resource, float weight) {
+            this.resource = resource;
+            this.weight = weight;
+        }
+
+        public HerbType getResource() {
+            return resource;
+        }
+
+        public float getWeight() {
+            return weight;
+        }
+    }
+}

--- a/core/src/main/java/com/nova/healersinc/world/BiomeDefinition.java
+++ b/core/src/main/java/com/nova/healersinc/world/BiomeDefinition.java
@@ -8,12 +8,14 @@ import java.util.Random;
 public class BiomeDefinition {
     private final String id;
     private final String name;
+    private final Float worldGenWeight;
     private final Visual visual;
     private final SpawnRules spawnRules;
 
-    public BiomeDefinition(String id, String name, Visual visual, SpawnRules spawnRules) {
+    public BiomeDefinition(String id, String name, float worldGenWeight, Visual visual, SpawnRules spawnRules) {
         this.id = id;
         this.name = name;
+        this.worldGenWeight = worldGenWeight;
         this.visual = visual;
         this.spawnRules = spawnRules;
     }
@@ -24,6 +26,10 @@ public class BiomeDefinition {
 
     public String getName() {
         return name;
+    }
+
+    public Float getWorldGenWeight() {
+        return worldGenWeight;
     }
 
     public Visual getVisual() {

--- a/core/src/main/java/com/nova/healersinc/world/BiomeRegistry.java
+++ b/core/src/main/java/com/nova/healersinc/world/BiomeRegistry.java
@@ -1,0 +1,101 @@
+package com.nova.healersinc.world;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.utils.Json;
+import com.badlogic.gdx.utils.ObjectMap;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BiomeRegistry {
+
+    private static final String CONFIG_PATH = "biomes.json";
+
+    private static final ObjectMap<BiomeType, BiomeDefinition> DEFINITIONS = new ObjectMap<>();
+    private static final ObjectMap<String, BiomeType> ID_TO_BIOME = new ObjectMap<>();
+
+    private static boolean initialized = false;
+
+    /**
+     * Call this once during game startup to load all biomes
+     */
+    public static void init() {
+        if (initialized) return;
+
+        buildBiomeLookup();
+
+        FileHandle file = Gdx.files.internal(CONFIG_PATH);
+        if (!file.exists()) {
+            throw new RuntimeException("Biome config file not found: " + CONFIG_PATH);
+        }
+
+        Json json = new Json();
+        BiomeConfig config = json.fromJson(BiomeConfig.class, file);
+
+        for (BiomeConfig.BiomeEntry entry : config.biomes) {
+            BiomeDefinition definition = toDefinition(entry);
+            BiomeType biomeKey = mapIdToBiome(entry.id);
+            DEFINITIONS.put(biomeKey, definition);
+        }
+
+        initialized = true;
+        Gdx.app.log("BiomeRegistry", "Initialized with " + DEFINITIONS.size + " biomes.");
+    }
+
+    private static void buildBiomeLookup() {
+        for (BiomeType biome : BiomeType.values()) {
+            ID_TO_BIOME.put(biome.name().toLowerCase(), biome);
+        }
+    }
+
+    private static BiomeDefinition toDefinition(BiomeConfig.BiomeEntry e) {
+        Color color = Color.valueOf(e.visual.color);
+        BiomeDefinition.Visual visual = new BiomeDefinition.Visual(color, e.visual.texture);
+
+        // Convert resource spawns
+        List<BiomeDefinition.ResourceSpawn> resourceSpawns = new ArrayList<>();
+        for (BiomeConfig.ResourceSpawn spawn : e.spawnRules.resources) {
+            HerbType herb = mapIdToHerb(spawn.resourceId);
+            resourceSpawns.add(new BiomeDefinition.ResourceSpawn(herb, spawn.weight));
+        }
+
+        BiomeDefinition.SpawnRules spawnRules = new BiomeDefinition.SpawnRules(
+            e.spawnRules.clusterCenterChance,
+            resourceSpawns
+        );
+
+        return new BiomeDefinition(e.id, e.name, visual, spawnRules);
+    }
+
+    private static BiomeType mapIdToBiome(String id) {
+        BiomeType biome = ID_TO_BIOME.get(id);
+        if (biome == null) {
+            throw new IllegalArgumentException("Unknown biome id in JSON: '" + id + "'. " +
+                "Make sure it matches an enum constant name (case-insensitive).");
+        }
+        return biome;
+    }
+
+    private static HerbType mapIdToHerb(String id) {
+        try {
+            return HerbType.valueOf(id.toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            throw new IllegalArgumentException("Unknown herb id in biome config: '" + id + "'");
+        }
+    }
+
+    public static BiomeDefinition getDefinition(BiomeType biome) {
+        if (!initialized) {
+            throw new IllegalStateException("BiomeRegistry not initialized! Call BiomeRegistry.init() during startup.");
+        }
+
+        BiomeDefinition def = DEFINITIONS.get(biome);
+        if (def == null) {
+            throw new IllegalArgumentException("No biome definition found for: " + biome.name());
+        }
+
+        return def;
+    }
+}

--- a/core/src/main/java/com/nova/healersinc/world/BiomeType.java
+++ b/core/src/main/java/com/nova/healersinc/world/BiomeType.java
@@ -1,7 +1,7 @@
 package com.nova.healersinc.world;
 
 public enum BiomeType {
-    SUNNY_MEADOW,
-    SHADY_GROVE,
-    SWAMP
+    MILD_MEADOW,
+    GROOVY_GROVE,
+    SPOOKY_SWAMP
 }

--- a/core/src/main/java/com/nova/healersinc/world/WorldGenerator.java
+++ b/core/src/main/java/com/nova/healersinc/world/WorldGenerator.java
@@ -132,16 +132,8 @@ public class WorldGenerator {
     }
 
     private HerbType getHerbTypeForBiome(BiomeType biome) {
-        switch (biome) {
-            case MILD_MEADOW:
-                // 70% Chamomile, 30% Mint in sunny meadows
-                return random.nextFloat() < 0.7f ? HerbType.CHAMOMILE : HerbType.MINT;
-            case GROOVY_GROVE:
-                // 60% Mint, 40% Echinacea in shady groves
-                return random.nextFloat() < 0.6f ? HerbType.MINT : HerbType.ECHINACEA;
-            default:
-                return HerbType.CHAMOMILE;
-        }
+        BiomeDefinition def = BiomeRegistry.getDefinition(biome);
+        return def.getSpawnRules().pickRandomHerb(random);
     }
 
     private HerbNode createHerbNode(HerbType type) {

--- a/core/src/main/java/com/nova/healersinc/world/WorldGenerator.java
+++ b/core/src/main/java/com/nova/healersinc/world/WorldGenerator.java
@@ -73,9 +73,7 @@ public class WorldGenerator {
     }
 
     private BiomeType randomBiome() {
-        return random.nextFloat() < 0.6f
-            ? BiomeType.MILD_MEADOW
-            : BiomeType.GROOVY_GROVE;
+        return BiomeRegistry.pickRandomBiome(random);
     }
 
     private boolean shouldBeHerbClusterCenter(BiomeType biome) {

--- a/core/src/main/java/com/nova/healersinc/world/WorldGenerator.java
+++ b/core/src/main/java/com/nova/healersinc/world/WorldGenerator.java
@@ -79,18 +79,8 @@ public class WorldGenerator {
     }
 
     private boolean shouldBeHerbClusterCenter(BiomeType biome) {
-        float roll = random.nextFloat();
-
-        switch (biome) {
-            case MILD_MEADOW:
-                // 1% chance for a cluster center
-                return roll < 0.01f;
-
-            case GROOVY_GROVE:
-                // 1% chance for a cluster center
-                return roll < 0.005f;
-        }
-        return false;
+        BiomeDefinition def = BiomeRegistry.getDefinition(biome);
+        return random.nextFloat() < def.getSpawnRules().getClusterCenterChance();
     }
 
     private void growHerbClusters(WorldMap worldMap, BiomeType[][] tileBiomes, List<int[]> clusterCenters) {

--- a/core/src/main/java/com/nova/healersinc/world/WorldGenerator.java
+++ b/core/src/main/java/com/nova/healersinc/world/WorldGenerator.java
@@ -74,19 +74,19 @@ public class WorldGenerator {
 
     private BiomeType randomBiome() {
         return random.nextFloat() < 0.6f
-            ? BiomeType.SUNNY_MEADOW
-            : BiomeType.SHADY_GROVE;
+            ? BiomeType.MILD_MEADOW
+            : BiomeType.GROOVY_GROVE;
     }
 
     private boolean shouldBeHerbClusterCenter(BiomeType biome) {
         float roll = random.nextFloat();
 
         switch (biome) {
-            case SUNNY_MEADOW:
+            case MILD_MEADOW:
                 // 1% chance for a cluster center
                 return roll < 0.01f;
 
-            case SHADY_GROVE:
+            case GROOVY_GROVE:
                 // 1% chance for a cluster center
                 return roll < 0.005f;
         }
@@ -143,10 +143,10 @@ public class WorldGenerator {
 
     private HerbType getHerbTypeForBiome(BiomeType biome) {
         switch (biome) {
-            case SUNNY_MEADOW:
+            case MILD_MEADOW:
                 // 70% Chamomile, 30% Mint in sunny meadows
                 return random.nextFloat() < 0.7f ? HerbType.CHAMOMILE : HerbType.MINT;
-            case SHADY_GROVE:
+            case GROOVY_GROVE:
                 // 60% Mint, 40% Echinacea in shady groves
                 return random.nextFloat() < 0.6f ? HerbType.MINT : HerbType.ECHINACEA;
             default:


### PR DESCRIPTION
### Summary

This pull request introduces a new biome system, including a JSON-based configuration and dynamic registry, as well as a weighted random selection logic for biome generation.

### Changes

- **Features:**
  - Added `worldGenWeight` to `biomes.json` for controlling biome selection probabilities.
  - Implemented weighted random biome selection using cumulative weights.
  - Introduced a JSON-based configuration file (`biomes.json`) for defining biome attributes, visuals, and spawn rules.
  - Added `BiomeRegistry`, initialized during game startup.

- **Refactors:**
  - Delegated biome color logic to `BiomeRegistry` definitions for improved consistency.
  - Simplified herb type and cluster spawn rules by leveraging biome registry definitions.
  - Renamed biome-related references in `WorldGenerator` and `MapRenderer` for clarity.

### Motivation

These changes provide a more flexible and maintainable system for handling biomes, improving both customization and computational efficiency in world generation.